### PR TITLE
Laravel 5.8 renders throttle security check useless

### DIFF
--- a/src/Command/ThrottleLogin.php
+++ b/src/Command/ThrottleLogin.php
@@ -37,8 +37,12 @@ class ThrottleLogin
         ThrottleSecurityCheckExtension $extension
     ) {
         $maxAttempts      = $settings->value('anomaly.extension.throttle_security_check::max_attempts', 5);
-        $lockoutInterval  = $settings->value('anomaly.extension.throttle_security_check::lockout_interval', 1);
-        $throttleInterval = $settings->value('anomaly.extension.throttle_security_check::throttle_interval', 1);
+        $lockoutInterval  = now()->addMinutes(
+            $settings->value('anomaly.extension.throttle_security_check::lockout_interval', 1)
+        );
+        $throttleInterval = now()->addMinutes(
+            $settings->value('anomaly.extension.throttle_security_check::throttle_interval', 1)
+        );
 
         $attempts   = $cache->get($extension->getNamespace('attempts:' . $request->ip()), 1);
         $expiration = $cache->get($extension->getNamespace('expiration:' . $request->ip()));


### PR DESCRIPTION
As of Laravel 5.8 the cache expiration time changed from minutes to seconds.  This means this security check does not work any longer as the cache expires after 1 second rendering it useless.  This could be fixed by simply multiplying all of the settings values by 60 to get number of seconds but it may break again in the future.  The proper fix is to pass in a valid Carbon date for expiration instructing the cache to expire at an exact time.